### PR TITLE
change searchSpacePath to point to example config

### DIFF
--- a/xt_training/utils/nni/nni_config_example.yml
+++ b/xt_training/utils/nni/nni_config_example.yml
@@ -7,7 +7,7 @@ maxExecDuration: 40m
 maxTrialNum: 100
 #choice: local, remote, pai
 trainingServicePlatform: local
-searchSpacePath: search_space.json
+searchSpacePath: search_space_example.json
 #choice: true, false
 useAnnotation: false
 tuner:


### PR DESCRIPTION
change searchSpacePath to point to example config file, instead of pointing to a non-existing config file. 

summary of the change
- Change searchSpacePath in example config

relevant motivation
- Demo NNI experiments fail to run out-of-box due to this incorrect value

context
- Demo NNI run of detection sub-repo in `smart-objects`. 

Change type:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation

Checklist:

- [x] My code follows the style guidelines of this [project](https://docs.google.com/document/d/1jckZJe0CrWyF-IjxoO2OfBKAyKLC3Yk9Xr7UmOLBETA/edit?usp=sharing)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code and added docstrings to all exposed functions and classes
- [ ] I have made corresponding changes to the documentation
- [ ] Any relevant changes to third party licenses have been updated in the README
