### PR TITLE
Use default on exit functions in config_example.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools, os
 
 PACKAGE_NAME = 'xt-training'
-VERSION = '2.3.0'
+VERSION = '2.3.1'
 AUTHOR = 'Xtract AI'
 EMAIL = 'info@xtract.ai'
 DESCRIPTION = 'Utilities for training models in pytorch'

--- a/xt_training/utils/config_example.py
+++ b/xt_training/utils/config_example.py
@@ -47,7 +47,7 @@ from torch.optim import lr_scheduler
 from torchvision import models, transforms
 import numpy as np
 from xt_training import metrics
-from xt_training.utils import training, testing
+from xt_training.utils import training, testing, functional
 
 # Dataset
 train_dataset = torch.utils.data.TensorDataset(
@@ -108,10 +108,8 @@ scheduler = lr_scheduler.MultiStepLR(optimizer, milestones=[5])
 
 
 # Function to run after training
-def train_exit(config, runner, save_dir):
-    training.default_exit(config, runner, save_dir)
+train_exit = functional.train_exit
 
 
 # Function to run after testing
-def test_exit(config, runner, save_dir):
-    testing.default_exit(config, runner, save_dir)
+test_exit = functional.test_exit


### PR DESCRIPTION
Fixes #31

<summary of the change, relevant motivation, and context>

Change type:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation

Checklist:

- [x] My code follows the style guidelines of this [project](https://docs.google.com/document/d/1jckZJe0CrWyF-IjxoO2OfBKAyKLC3Yk9Xr7UmOLBETA/edit?usp=sharing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code and added docstrings to all exposed functions and classes
- [x] I have made corresponding changes to the documentation
- [x] Any relevant changes to third party licenses have been updated in the README
