### PR TITLE
overload state_dict methods for skinterface

### DIFF
--- a/xt_training/utils/sklearn_wrapper.py
+++ b/xt_training/utils/sklearn_wrapper.py
@@ -133,6 +133,12 @@ class SKInterface(nn.Module):
     def eval(self):
         return self.train(False)
 
+    def state_dict(self):
+        return {'base_model' : self.base_model}
+
+    def load_state_dict(self, d):
+        self.base_model = d['base_model']
+
 
 class DummyOptimizer:
     """A dummy optimizer class to use with the SKInterface in xt-training."""


### PR DESCRIPTION
SKInterface has no learnable parameters, so empty state_dicts where being saved and all progress was lost. This overloads the `state_dict` and `load_state_dict` to return a dict with the `base_model`. SKInterfaces now work as expected in `xt_training`.

Change type:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation

Checklist:

- [x] My code follows the style guidelines of this [project](https://docs.google.com/document/d/1jckZJe0CrWyF-IjxoO2OfBKAyKLC3Yk9Xr7UmOLBETA/edit?usp=sharing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code and added docstrings to all exposed functions and classes
- [x] I have made corresponding changes to the documentation
- [x] Any relevant changes to third party licenses have been updated in the README
