### PR TITLE
Added starting loss to functional train

### DIFF
--- a/xt_training/utils/functional.py
+++ b/xt_training/utils/functional.py
@@ -26,6 +26,7 @@ def train(
     optimizer,
     epochs,
     loss_fn,
+    starting_loss=None,
     overwrite=True,
     val_loader=None,
     test_loaders=None,
@@ -89,11 +90,11 @@ def train(
         for loader_name, loader in test_loaders.items():
             runner(loader, loader_name)
 
-    best_loss = 1e12
-    if val_loader:
+    best_loss = 1e12 if starting_loss is None else starting_loss
+    if val_loader and starting_loss is None:
         model.eval()
         runner(val_loader, 'valid')
-        best_loss = runner.loss()
+        best_loss = min(runner.loss(), best_loss)
 
     runner.save_model(save_dir, True)
 

--- a/xt_training/utils/functional.py
+++ b/xt_training/utils/functional.py
@@ -45,7 +45,8 @@ def train(
         model (Model): Pytorch model to be trained
         optimizer (optim.Optimizer): Optimizer (ex. Adam, SGD)
         epochs (int): Number of epochs to run training for
-        loss_fn (fn): A function that takes y, ypred and outputs loss 
+        loss_fn (fn): A function that takes y, ypred and outputs loss
+        starting_loss (float, optional): starting point for best loss
         overwrite (bool, optional): Whether or not to overwrite save_dir. Defaults to True.
         val_loader (Dataloader, optional): PyTorch dataloader for validation. Defaults to None.
         test_loaders (dict, optional): A dict of PyTorch datlaoaders for testing. Defaults to None.


### PR DESCRIPTION
Added a parameter to functional train: `starting_loss`. This is useful when tracking loss across multiple calls to the train function (eg training on multiple data splits) because it will only save the model as 'best' if the loss is lower than `starting_loss`. The behavior of `train` is unchanged if `starting_loss` isn't specified.

Change type:

- [ ] Bug fix
- [x] Feature
- [ ] Documentation

Checklist:

- [x] My code follows the style guidelines of this [project](https://docs.google.com/document/d/1jckZJe0CrWyF-IjxoO2OfBKAyKLC3Yk9Xr7UmOLBETA/edit?usp=sharing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code and added docstrings to all exposed functions and classes
- [x] I have made corresponding changes to the documentation
- [x] Any relevant changes to third party licenses have been updated in the README
