### PR TITLE
Allow interrupt in notebook without breaking logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools, os
 
 PACKAGE_NAME = 'xt-training'
-VERSION = '2.3.4'
+VERSION = '2.3.5'
 AUTHOR = 'Xtract AI'
 EMAIL = 'info@xtract.ai'
 DESCRIPTION = 'Utilities for training models in pytorch'

--- a/xt_training/utils/functional.py
+++ b/xt_training/utils/functional.py
@@ -64,43 +64,43 @@ def train(
     if overwrite and os.path.isdir(save_dir):
         shutil.rmtree(save_dir)
     os.makedirs(save_dir, exist_ok=True)
-    
+
     with Tee(os.path.join(save_dir, "train.log")):
 
-        if tokenizer is not None and hasattr(tokenizer, 'save_pretrained'):
-            tokenizer.save_pretrained(save_dir)
-
-        device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-        print('Running on device: {}'.format(device))
-        if hasattr(loss_fn, 'weight') and loss_fn.weight is not None:
-            loss_fn.weight = loss_fn.weight.to(device)
-        model = model.to(device)
-
-        # Create tensorboard writer
-        writer = SummaryWriter(save_dir, flush_secs=30)
-
-        # Define model runner
-        runner = Runner(
-            model, loss_fn, optimizer, scheduler, batch_metrics=eval_metrics,
-            device=device, writer=writer, is_batch_scheduler=is_batch_scheduler
-        )
-
-        if test_loaders:
-            print('\n\nInitial')
-            print('-' * 10)
-            model.eval()
-            for loader_name, loader in test_loaders.items():
-                runner(loader, loader_name)
-
-        best_loss = 1e12 if starting_loss is None else starting_loss
-        if val_loader and starting_loss is None:
-            model.eval()
-            runner(val_loader, 'valid')
-            best_loss = min(runner.loss(), best_loss)
-
-        runner.save_model(save_dir, True)
-
         try:
+            if tokenizer is not None and hasattr(tokenizer, 'save_pretrained'):
+                tokenizer.save_pretrained(save_dir)
+
+            device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+            print('Running on device: {}'.format(device))
+            if hasattr(loss_fn, 'weight') and loss_fn.weight is not None:
+                loss_fn.weight = loss_fn.weight.to(device)
+            model = model.to(device)
+
+            # Create tensorboard writer
+            writer = SummaryWriter(save_dir, flush_secs=30)
+
+            # Define model runner
+            runner = Runner(
+                model, loss_fn, optimizer, scheduler, batch_metrics=eval_metrics,
+                device=device, writer=writer, is_batch_scheduler=is_batch_scheduler
+            )
+
+            if test_loaders:
+                print('\n\nInitial')
+                print('-' * 10)
+                model.eval()
+                for loader_name, loader in test_loaders.items():
+                    runner(loader, loader_name)
+
+            best_loss = 1e12 if starting_loss is None else starting_loss
+            if val_loader and starting_loss is None:
+                model.eval()
+                runner(val_loader, 'valid')
+                best_loss = min(runner.loss(), best_loss)
+
+            runner.save_model(save_dir, True)
+
             for epoch in range(epochs):
                 print('\nEpoch {}/{}'.format(epoch + 1, epochs))
                 print('-' * 10) 
@@ -128,21 +128,19 @@ def train(
             if use_nni:
                 metrics_dict = {k:v.item() for k,v in runner.latest['metrics'].items()}
                 nni.report_final_result({'default':best_loss.item(),**metrics_dict})
-        
+
         # Allow safe interruption of training loop
         except KeyboardInterrupt:
             print('\n\nExiting with honour\n')
-            pass
+            raise(KeyboardInterrupt)
 
         except Exception as e:
             print('\n\nDishonourable exit\n')
             raise e
-
-        out = on_exit(test_loaders=test_loaders, model=model, runner=runner, save_dir=save_dir)
-
-        writer.close()
-
-    return out
+        else:
+            out = on_exit(test_loaders=test_loaders, model=model, runner=runner, save_dir=save_dir)
+            writer.close()
+            return out
 
 
 def test_exit(test_loaders, model, runner, save_dir):
@@ -157,7 +155,7 @@ def test(
     test_loaders=None,
     loss_fn=lambda *_: torch.tensor(0.),
     eval_metrics={'eps': metrics.EPS()},
-    on_exit=test_exit
+    on_exit=test_exit,
 ):
     """Utility function to test a model
 
@@ -174,47 +172,52 @@ def test(
         Any: Returns the output of on_exit, if any
     """
     # Initialize logging
-    if save_dir:
-        os.makedirs(save_dir, exist_ok=True)
-        tee = Tee(os.path.join(save_dir, "test.log"))
-        results = {}
-
-    device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-    print('Running on device: {}'.format(device))
-    model = model.to(device)
-    
-    if checkpoint_path is not None:
-        if os.path.isdir(checkpoint_path):
-            checkpoint_path = checkpoint_path + 'best.pt'
-        model.load_state_dict(torch.load(checkpoint_path))
-    model.eval()
-
-    # Define model runner
-    runner = Runner(model, loss_fn, batch_metrics=eval_metrics, device=device)
-
-    if val_loader:
-        print('\n\nValidation')
-        print('-' * 10)
-        if save_dir:
-            preds, labels = runner(val_loader, 'valid', return_preds=True)
-            results['valid'] = {'preds': preds, 'labels': labels}
-        else:
-            runner(val_loader, 'valid')
-
-    if test_loaders:
-        print('\nTest')
-        print('-' * 10)
-        for loader_name, loader in test_loaders.items():
+    with Tee(os.path.join(save_dir, "test.log")):
+        try:
             if save_dir:
-                preds, labels = runner(loader, loader_name, return_preds=True)
-                results[loader_name] = {'preds': preds, 'labels': labels}
-            else:
-                runner(loader, loader_name)
+                os.makedirs(save_dir, exist_ok=True)
+                results = {}
 
-    out = on_exit(test_loaders, model, runner, save_dir)
+            device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+            print('Running on device: {}'.format(device))
+            model = model.to(device)
 
-    if save_dir:
-        torch.save(results, os.path.join(save_dir, 'results.pt'))
-        tee.close()
-    
-    return out
+            if checkpoint_path is not None:
+                if os.path.isdir(checkpoint_path):
+                    checkpoint_path = checkpoint_path + 'best.pt'
+                model.load_state_dict(torch.load(checkpoint_path))
+            model.eval()
+
+            # Define model runner
+            runner = Runner(model, loss_fn, batch_metrics=eval_metrics, device=device)
+
+            if val_loader:
+                print('\n\nValidation')
+                print('-' * 10)
+                if save_dir:
+                    preds, labels = runner(val_loader, 'valid', return_preds=True)
+                    results['valid'] = {'preds': preds, 'labels': labels}
+                else:
+                    runner(val_loader, 'valid')
+
+            if test_loaders:
+                print('\nTest')
+                print('-' * 10)
+                for loader_name, loader in test_loaders.items():
+                    if save_dir:
+                        preds, labels = runner(loader, loader_name, return_preds=True)
+                        results[loader_name] = {'preds': preds, 'labels': labels}
+                    else:
+                        runner(loader, loader_name)
+
+        except KeyboardInterrupt:
+            print('\n\nExiting with honour\n')
+            raise(KeyboardInterrupt)
+
+        except Exception as e:
+            print('\n\nDishonourable exit\n')
+            raise e
+        else:
+            out = on_exit(test_loaders, model, runner, save_dir)
+            torch.save(results, os.path.join(save_dir, 'results.pt'))
+            return out

--- a/xt_training/utils/functional.py
+++ b/xt_training/utils/functional.py
@@ -64,84 +64,83 @@ def train(
     if overwrite and os.path.isdir(save_dir):
         shutil.rmtree(save_dir)
     os.makedirs(save_dir, exist_ok=True)
-    tee = Tee(os.path.join(save_dir, "train.log"))
-
-    if tokenizer is not None and hasattr(tokenizer, 'save_pretrained'):
-        tokenizer.save_pretrained(save_dir)
-
-    device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-    print('Running on device: {}'.format(device))
-    if hasattr(loss_fn, 'weight') and loss_fn.weight is not None:
-        loss_fn.weight = loss_fn.weight.to(device)
-    model = model.to(device)
-
-    # Create tensorboard writer
-    writer = SummaryWriter(save_dir, flush_secs=30)
-
-    # Define model runner
-    runner = Runner(
-        model, loss_fn, optimizer, scheduler, batch_metrics=eval_metrics,
-        device=device, writer=writer, is_batch_scheduler=is_batch_scheduler
-    )
-
-    if test_loaders:
-        print('\n\nInitial')
-        print('-' * 10)
-        model.eval()
-        for loader_name, loader in test_loaders.items():
-            runner(loader, loader_name)
-
-    best_loss = 1e12 if starting_loss is None else starting_loss
-    if val_loader and starting_loss is None:
-        model.eval()
-        runner(val_loader, 'valid')
-        best_loss = min(runner.loss(), best_loss)
-
-    runner.save_model(save_dir, True)
-
-    try:
-        for epoch in range(epochs):
-            print('\nEpoch {}/{}'.format(epoch + 1, epochs))
-            print('-' * 10) 
-
-            if hasattr(model, 'update') and callable(model.update):
-                model.update(epoch + 1)
-
-            model.train()
-            runner(train_loader, 'train')
-
-            if val_loader:
-                model.eval()
-                runner(val_loader, 'valid')
-                metrics_dict = {k:v.item() for k,v in runner.latest['metrics'].items()}
-                if use_nni:
-                    nni.report_intermediate_result({'default':runner.loss().item(),**metrics_dict})
-
-            if runner.loss() < best_loss:
-                runner.save_model(save_dir, True)
-                best_loss = runner.loss()
-                print(f'Saved new best: {best_loss:.4}')
-            else:
-                runner.save_model(save_dir, False)
-
-        if use_nni:
-            metrics_dict = {k:v.item() for k,v in runner.latest['metrics'].items()}
-            nni.report_final_result({'default':best_loss.item(),**metrics_dict})
     
-    # Allow safe interruption of training loop
-    except KeyboardInterrupt:
-        print('\n\nExiting with honour\n')
-        pass
+    with Tee(os.path.join(save_dir, "train.log")):
 
-    except Exception as e:
-        print('\n\nDishonourable exit\n')
-        raise e
+        if tokenizer is not None and hasattr(tokenizer, 'save_pretrained'):
+            tokenizer.save_pretrained(save_dir)
 
-    out = on_exit(test_loaders=test_loaders, model=model, runner=runner, save_dir=save_dir)
+        device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+        print('Running on device: {}'.format(device))
+        if hasattr(loss_fn, 'weight') and loss_fn.weight is not None:
+            loss_fn.weight = loss_fn.weight.to(device)
+        model = model.to(device)
 
-    writer.close()
-    tee.flush()
-    tee.close()
+        # Create tensorboard writer
+        writer = SummaryWriter(save_dir, flush_secs=30)
+
+        # Define model runner
+        runner = Runner(
+            model, loss_fn, optimizer, scheduler, batch_metrics=eval_metrics,
+            device=device, writer=writer, is_batch_scheduler=is_batch_scheduler
+        )
+
+        if test_loaders:
+            print('\n\nInitial')
+            print('-' * 10)
+            model.eval()
+            for loader_name, loader in test_loaders.items():
+                runner(loader, loader_name)
+
+        best_loss = 1e12 if starting_loss is None else starting_loss
+        if val_loader and starting_loss is None:
+            model.eval()
+            runner(val_loader, 'valid')
+            best_loss = min(runner.loss(), best_loss)
+
+        runner.save_model(save_dir, True)
+
+        try:
+            for epoch in range(epochs):
+                print('\nEpoch {}/{}'.format(epoch + 1, epochs))
+                print('-' * 10) 
+
+                if hasattr(model, 'update') and callable(model.update):
+                    model.update(epoch + 1)
+
+                model.train()
+                runner(train_loader, 'train')
+
+                if val_loader:
+                    model.eval()
+                    runner(val_loader, 'valid')
+                    metrics_dict = {k:v.item() for k,v in runner.latest['metrics'].items()}
+                    if use_nni:
+                        nni.report_intermediate_result({'default':runner.loss().item(),**metrics_dict})
+
+                if runner.loss() < best_loss:
+                    runner.save_model(save_dir, True)
+                    best_loss = runner.loss()
+                    print(f'Saved new best: {best_loss:.4}')
+                else:
+                    runner.save_model(save_dir, False)
+
+            if use_nni:
+                metrics_dict = {k:v.item() for k,v in runner.latest['metrics'].items()}
+                nni.report_final_result({'default':best_loss.item(),**metrics_dict})
+        
+        # Allow safe interruption of training loop
+        except KeyboardInterrupt:
+            print('\n\nExiting with honour\n')
+            pass
+
+        except Exception as e:
+            print('\n\nDishonourable exit\n')
+            raise e
+
+        out = on_exit(test_loaders=test_loaders, model=model, runner=runner, save_dir=save_dir)
+
+        writer.close()
 
     return out
 
@@ -216,7 +215,6 @@ def test(
 
     if save_dir:
         torch.save(results, os.path.join(save_dir, 'results.pt'))
-        tee.flush()
         tee.close()
     
     return out

--- a/xt_training/utils/functional.py
+++ b/xt_training/utils/functional.py
@@ -67,40 +67,40 @@ def train(
 
     with Tee(os.path.join(save_dir, "train.log")):
 
+        if tokenizer is not None and hasattr(tokenizer, 'save_pretrained'):
+            tokenizer.save_pretrained(save_dir)
+
+        device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+        print('Running on device: {}'.format(device))
+        if hasattr(loss_fn, 'weight') and loss_fn.weight is not None:
+            loss_fn.weight = loss_fn.weight.to(device)
+        model = model.to(device)
+
+        # Create tensorboard writer
+        writer = SummaryWriter(save_dir, flush_secs=30)
+
+        # Define model runner
+        runner = Runner(
+            model, loss_fn, optimizer, scheduler, batch_metrics=eval_metrics,
+            device=device, writer=writer, is_batch_scheduler=is_batch_scheduler
+        )
+
+        if test_loaders:
+            print('\n\nInitial')
+            print('-' * 10)
+            model.eval()
+            for loader_name, loader in test_loaders.items():
+                runner(loader, loader_name)
+
+        best_loss = 1e12 if starting_loss is None else starting_loss
+        if val_loader and starting_loss is None:
+            model.eval()
+            runner(val_loader, 'valid')
+            best_loss = min(runner.loss(), best_loss)
+
+        runner.save_model(save_dir, True)
+
         try:
-            if tokenizer is not None and hasattr(tokenizer, 'save_pretrained'):
-                tokenizer.save_pretrained(save_dir)
-
-            device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-            print('Running on device: {}'.format(device))
-            if hasattr(loss_fn, 'weight') and loss_fn.weight is not None:
-                loss_fn.weight = loss_fn.weight.to(device)
-            model = model.to(device)
-
-            # Create tensorboard writer
-            writer = SummaryWriter(save_dir, flush_secs=30)
-
-            # Define model runner
-            runner = Runner(
-                model, loss_fn, optimizer, scheduler, batch_metrics=eval_metrics,
-                device=device, writer=writer, is_batch_scheduler=is_batch_scheduler
-            )
-
-            if test_loaders:
-                print('\n\nInitial')
-                print('-' * 10)
-                model.eval()
-                for loader_name, loader in test_loaders.items():
-                    runner(loader, loader_name)
-
-            best_loss = 1e12 if starting_loss is None else starting_loss
-            if val_loader and starting_loss is None:
-                model.eval()
-                runner(val_loader, 'valid')
-                best_loss = min(runner.loss(), best_loss)
-
-            runner.save_model(save_dir, True)
-
             for epoch in range(epochs):
                 print('\nEpoch {}/{}'.format(epoch + 1, epochs))
                 print('-' * 10) 
@@ -132,12 +132,11 @@ def train(
         # Allow safe interruption of training loop
         except KeyboardInterrupt:
             print('\n\nExiting with honour\n')
-            raise(KeyboardInterrupt)
 
         except Exception as e:
             print('\n\nDishonourable exit\n')
             raise e
-        else:
+        finally:
             out = on_exit(test_loaders=test_loaders, model=model, runner=runner, save_dir=save_dir)
             writer.close()
             return out
@@ -173,51 +172,42 @@ def test(
     """
     # Initialize logging
     with Tee(os.path.join(save_dir, "test.log")):
-        try:
+        if save_dir:
+            os.makedirs(save_dir, exist_ok=True)
+            results = {}
+
+        device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+        print('Running on device: {}'.format(device))
+        model = model.to(device)
+
+        if checkpoint_path is not None:
+            if os.path.isdir(checkpoint_path):
+                checkpoint_path = checkpoint_path + 'best.pt'
+            model.load_state_dict(torch.load(checkpoint_path))
+        model.eval()
+
+        # Define model runner
+        runner = Runner(model, loss_fn, batch_metrics=eval_metrics, device=device)
+
+        if val_loader:
+            print('\n\nValidation')
+            print('-' * 10)
             if save_dir:
-                os.makedirs(save_dir, exist_ok=True)
-                results = {}
+                preds, labels = runner(val_loader, 'valid', return_preds=True)
+                results['valid'] = {'preds': preds, 'labels': labels}
+            else:
+                runner(val_loader, 'valid')
 
-            device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-            print('Running on device: {}'.format(device))
-            model = model.to(device)
-
-            if checkpoint_path is not None:
-                if os.path.isdir(checkpoint_path):
-                    checkpoint_path = checkpoint_path + 'best.pt'
-                model.load_state_dict(torch.load(checkpoint_path))
-            model.eval()
-
-            # Define model runner
-            runner = Runner(model, loss_fn, batch_metrics=eval_metrics, device=device)
-
-            if val_loader:
-                print('\n\nValidation')
-                print('-' * 10)
+        if test_loaders:
+            print('\nTest')
+            print('-' * 10)
+            for loader_name, loader in test_loaders.items():
                 if save_dir:
-                    preds, labels = runner(val_loader, 'valid', return_preds=True)
-                    results['valid'] = {'preds': preds, 'labels': labels}
+                    preds, labels = runner(loader, loader_name, return_preds=True)
+                    results[loader_name] = {'preds': preds, 'labels': labels}
                 else:
-                    runner(val_loader, 'valid')
+                    runner(loader, loader_name)
 
-            if test_loaders:
-                print('\nTest')
-                print('-' * 10)
-                for loader_name, loader in test_loaders.items():
-                    if save_dir:
-                        preds, labels = runner(loader, loader_name, return_preds=True)
-                        results[loader_name] = {'preds': preds, 'labels': labels}
-                    else:
-                        runner(loader, loader_name)
-
-        except KeyboardInterrupt:
-            print('\n\nExiting with honour\n')
-            raise(KeyboardInterrupt)
-
-        except Exception as e:
-            print('\n\nDishonourable exit\n')
-            raise e
-        else:
-            out = on_exit(test_loaders, model, runner, save_dir)
-            torch.save(results, os.path.join(save_dir, 'results.pt'))
-            return out
+        out = on_exit(test_loaders, model, runner, save_dir)
+        torch.save(results, os.path.join(save_dir, 'results.pt'))
+        return out

--- a/xt_training/utils/logging.py
+++ b/xt_training/utils/logging.py
@@ -13,6 +13,12 @@ class Tee(object):
         self.file = open(logfile, "w")
         self.stdout = sys.stdout
         sys.stdout = self
+    
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
 
     def close(self):
         if self.stdout is not None:


### PR DESCRIPTION
This implements our logging splitter as a context manager to ensure that it correctly handles interrupts and exceptions. With this change, exceptions encountered during model training should no longer break logging in ipython (including jupyter).

Test by pulling this branch, running `pip install .` in it, then try breaking something in a Jupyter notebook.

Change type:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation

Checklist:

- [x] My code follows the style guidelines of this [project](https://docs.google.com/document/d/1jckZJe0CrWyF-IjxoO2OfBKAyKLC3Yk9Xr7UmOLBETA/edit?usp=sharing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code and added docstrings to all exposed functions and classes
- [x] I have made corresponding changes to the documentation
- [x] Any relevant changes to third party licenses have been updated in the README
