### PR TITLE
Save git commit and diff information for reproducibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .vscode
 data
 site
+.pytest_cache

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools, os
 
 PACKAGE_NAME = 'xt-training'
-VERSION = '2.3.5'
+VERSION = '2.4.0'
 AUTHOR = 'Xtract AI'
 EMAIL = 'info@xtract.ai'
 DESCRIPTION = 'Utilities for training models in pytorch'
@@ -39,6 +39,7 @@ setuptools.setup(
         'scikit-learn>=0.22',
         'plotly',
         'pynvml',
-        'nni'
+        'nni',
+        'gitpython',
     ],
 )

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -40,16 +40,14 @@ def test_save_state(repo, tmp_path, current_config_path):
     save_dir = tmp_path
     repo_path = repo.git.rev_parse("--show-toplevel")
     
-    expected_output_file_path = Path(save_dir).joinpath('git.patch')
     expected_commit_hash = repo.head.object.hexsha
     expected_untracked_file_name = 'an_untracked_file.py'
     expected_diff_text = 'this text was not committed'
     
-
     os.chdir(repo_path)
-
     _save_state(save_dir, str(current_config_path))
 
+    expected_output_file_path = Path(save_dir).joinpath('git.patch')
     assert expected_output_file_path.exists(), 'git.patch file was not successfully created'
 
     output_string = expected_output_file_path.read_text()

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -5,17 +5,19 @@ import pytest
 from pathlib import Path
 from xt_training.utils.logging import _save_state
 
+def create_file(file_path):
+    open(file_path, 'a').close()
+
 @pytest.fixture
 def current_config_path(tmp_path):
+
     config_path = Path(tmp_path).joinpath('current_config')
     config_path.mkdir(parents=True)
+
     config_file_path = config_path.joinpath('current_config.py')
-    open(config_file_path, 'a').close()
+    create_file(config_file_path)
 
     return config_file_path
-
-def create_file(path, file_name):
-    open(path.joinpath(file_name), 'a').close()
 
 
 @pytest.fixture(name='repo')
@@ -24,13 +26,17 @@ def dummy_git_repo(tmp_path):
     repo_path = tmp_path
     repo = git.Repo.init(repo_path)
 
-    create_file(repo_path, 'text_file.txt')
-    repo.index.add(['text_file.txt'])
+    file_name_temp = 'text_file.txt'
+
+    file_path_temp = repo_path.joinpath(file_name_temp)
+
+    create_file(file_path_temp)
+    repo.index.add([file_name_temp])
     repo.index.commit('dummy commit')
 
-    Path(repo_path.joinpath('text_file.txt')).write_text('this text was not committed')
+    Path(file_path_temp).write_text('this text was not committed')
 
-    create_file(repo_path, 'an_untracked_file.py')
+    create_file(repo_path.joinpath('an_untracked_file.py'))
 
     return repo
 

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -1,0 +1,59 @@
+import git
+import os
+import pytest
+
+from pathlib import Path
+from xt_training.utils.logging import _save_state
+
+@pytest.fixture
+def current_config_path(tmp_path):
+    config_path = Path(tmp_path).joinpath('current_config')
+    config_path.mkdir(parents=True)
+    config_file_path = config_path.joinpath('current_config.py')
+    open(config_file_path, 'a').close()
+
+    return config_file_path
+
+def create_file(path, file_name):
+    open(path.joinpath(file_name), 'a').close()
+
+
+@pytest.fixture(name='repo')
+def dummy_git_repo(tmp_path):
+
+    repo_path = tmp_path
+    repo = git.Repo.init(repo_path)
+
+    create_file(repo_path, 'text_file.txt')
+    repo.index.add(['text_file.txt'])
+    repo.index.commit('dummy commit')
+
+    Path(repo_path.joinpath('text_file.txt')).write_text('this text was not committed')
+
+    create_file(repo_path, 'an_untracked_file.py')
+
+    return repo
+
+
+def test_save_state(repo, tmp_path, current_config_path):
+
+    save_dir = tmp_path
+    repo_path = repo.git.rev_parse("--show-toplevel")
+    
+    expected_output_file_path = Path(save_dir).joinpath('git.patch')
+    expected_commit_hash = repo.head.object.hexsha
+    expected_untracked_file_name = 'an_untracked_file.py'
+    expected_diff_text = 'this text was not committed'
+    
+
+    os.chdir(repo_path)
+
+    _save_state(save_dir, str(current_config_path))
+
+    assert expected_output_file_path.exists(), 'git.patch file was not successfully created'
+
+    output_string = expected_output_file_path.read_text()
+    assert expected_commit_hash in output_string, 'Commit hash was not as expected'
+    assert expected_untracked_file_name in output_string, 'Untracked file list is incorrect'
+    assert expected_diff_text in output_string, 'Did not record diff of file'
+

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -34,7 +34,7 @@ def dummy_git_repo(tmp_path):
     repo.index.add([file_name_temp])
     repo.index.commit('dummy commit')
 
-    Path(file_path_temp).write_text('this text was not committed')
+    file_path_temp.write_text('this text was not committed')
 
     create_file(repo_path.joinpath('an_untracked_file.py'))
 

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -3,10 +3,12 @@ import os
 import pytest
 
 from pathlib import Path
-from xt_training.utils.logging import _save_state
+from xt_training.utils.logging import _save_state, _save_config
+
 
 def create_file(file_path):
     open(file_path, 'a').close()
+
 
 @pytest.fixture
 def current_config_path(tmp_path):
@@ -51,7 +53,8 @@ def test_save_state(repo, tmp_path, current_config_path):
     expected_diff_text = 'this text was not committed'
     
     os.chdir(repo_path)
-    _save_state(save_dir, str(current_config_path))
+    _save_config(save_dir, str(current_config_path))
+    _save_state(save_dir)
 
     expected_output_file_path = Path(save_dir).joinpath('git.patch')
     assert expected_output_file_path.exists(), 'git.patch file was not successfully created'

--- a/xt_training/__init__.py
+++ b/xt_training/__init__.py
@@ -1,2 +1,3 @@
 from .runner import Runner
 from . import metrics
+from .utils import functional

--- a/xt_training/runner.py
+++ b/xt_training/runner.py
@@ -3,7 +3,7 @@ import numpy as np
 import json
 import shutil
 
-from collections import Iterable
+from collections.abc import Iterable
 from .metrics import EPS, PooledMean, Metric
 
 class Logger(object):

--- a/xt_training/utils/__init__.py
+++ b/xt_training/utils/__init__.py
@@ -1,5 +1,5 @@
 from .file_utils import template, _import_config
-from .logging import Tee, _save_state
+from .logging import Tee, _save_state, _save_config
 from .training import train
 from .testing import test
 from .sklearn_wrapper import SKDataset, SKInterface, DummyOptimizer

--- a/xt_training/utils/__init__.py
+++ b/xt_training/utils/__init__.py
@@ -1,5 +1,5 @@
 from .file_utils import template, _import_config
-from .logging import Tee
+from .logging import Tee, _save_state
 from .training import train
 from .testing import test
 from .sklearn_wrapper import SKDataset, SKInterface, DummyOptimizer

--- a/xt_training/utils/file_utils.py
+++ b/xt_training/utils/file_utils.py
@@ -13,8 +13,6 @@ def template(args):
         shutil.copy(os.path.join(nni_path, 'search_space_example.json'), args.save_dir)
 
 
-
-
 def _import_config(path):
     """Import a config file given a file path."""
     config_spec = spec_from_file_location("config", path)

--- a/xt_training/utils/logging.py
+++ b/xt_training/utils/logging.py
@@ -55,9 +55,9 @@ def _save_state(save_dir, config_path):
     # Save config file
     try:
         if isinstance(config_path, str):
-            shutil.copy(config_path, f'{save_dir}/config.py')
+            shutil.copy(config_path, os.path.join(save_dir, 'config.py'))
         else:
-            shutil.copy(config_path['__file__'], f'{save_dir}/config.py')
+            shutil.copy(config_path['__file__'], os.path.join(save_dir, 'config.py'))
     except shutil.SameFileError:
         pass
 
@@ -68,7 +68,7 @@ def _save_state(save_dir, config_path):
         untracked = repo.untracked_files
         diff = repo.git.diff()
 
-        with open(f'{save_dir}/git.patch', 'w') as f:
+        with open(os.path.join(save_dir, 'git.patch'), 'w') as f:
             f.write(PATCH_HEADER)
             f.write(f'\n\nCommit: {commit}')
             f.write('\n\nUntracked files:\n')

--- a/xt_training/utils/logging.py
+++ b/xt_training/utils/logging.py
@@ -1,4 +1,7 @@
 import sys
+import shutil
+
+import git
 
 
 class Tee(object):
@@ -38,3 +41,40 @@ class Tee(object):
 
     def __del__(self):
         self.close()
+
+
+PATCH_HEADER = '''
+To replicate the git state used for this checkpoint, run the following:
+
+    $ git checkout <commit hash shown below>
+    $ git apply <path to this file>
+'''
+
+
+def _save_state(save_dir, config_path):
+    # Save config file
+    try:
+        if isinstance(config_path, str):
+            shutil.copy(config_path, f'{save_dir}/config.py')
+        else:
+            shutil.copy(config_path['__file__'], f'{save_dir}/config.py')
+    except shutil.SameFileError:
+        pass
+
+    # If we are in a git repo, save git state file
+    try:
+        repo = git.Repo('.')
+        commit = repo.head.object.hexsha
+        untracked = repo.untracked_files
+        diff = repo.git.diff()
+
+        with open(f'{save_dir}/git.patch', 'w') as f:
+            f.write(PATCH_HEADER)
+            f.write(f'\n\nCommit: {commit}')
+            f.write('\n\nUntracked files:\n')
+            f.write('\n'.join(untracked))
+            f.write('\n\n')
+            f.write(diff)
+    # Silently skip if no git repo is found
+    except:
+        pass

--- a/xt_training/utils/logging.py
+++ b/xt_training/utils/logging.py
@@ -99,9 +99,11 @@ def _save_state(save_dir):
         # We are running in an interactive session
         try:
             if hasattr(main, 'In'):
+                # This is an IPython session (includes Jupyter)
                 with open(os.path.join(save_dir, 'session-ipython.py'), 'w') as f:
                     f.write('\n'.join(main.In))
             else:
+                # Otherwise assume we are in the built-in python console
                 with open(os.path.join(save_dir, 'session.py'), 'w') as f:
                     f.write(SESSION_HEADER)
                     history_len = readline.get_current_history_length()

--- a/xt_training/utils/testing.py
+++ b/xt_training/utils/testing.py
@@ -4,7 +4,7 @@ from importlib.util import spec_from_file_location, module_from_spec
 
 import torch
 from xt_training import Runner, metrics
-from xt_training.utils import _import_config, Tee, functional
+from xt_training.utils import _import_config, Tee, functional, _save_state
 
 
 def test(args):
@@ -49,13 +49,7 @@ def test(args):
         on_exit
     )
 
-    # Save config file
-    try:
-        if isinstance(config_path, str):
-            shutil.copy(config_path, f'{save_dir}/config.py')
-        else:
-            shutil.copy(config_path['__file__'], f'{save_dir}/config.py')
-    except shutil.SameFileError:
-        pass
+    # Save config file and repo state in checkpoint directory
+    _save_state(save_dir, config_path)
 
     return out

--- a/xt_training/utils/testing.py
+++ b/xt_training/utils/testing.py
@@ -4,7 +4,7 @@ from importlib.util import spec_from_file_location, module_from_spec
 
 import torch
 from xt_training import Runner, metrics
-from xt_training.utils import _import_config, Tee, functional, _save_state
+from xt_training.utils import _import_config, Tee, functional, _save_config
 
 
 def test(args):
@@ -49,7 +49,7 @@ def test(args):
         on_exit
     )
 
-    # Save config file and repo state in checkpoint directory
-    _save_state(save_dir, config_path)
+    # Save config file in checkpoint directory
+    _save_config(save_dir, config_path)
 
     return out

--- a/xt_training/utils/training.py
+++ b/xt_training/utils/training.py
@@ -6,7 +6,7 @@ from importlib.util import spec_from_file_location, module_from_spec
 import torch
 from torch.utils.tensorboard import SummaryWriter
 from xt_training import Runner, metrics
-from xt_training.utils import _import_config, Tee, functional, _save_state
+from xt_training.utils import _import_config, Tee, functional, _save_config
 
 
 def train(args):
@@ -51,8 +51,8 @@ def train(args):
         on_exit=on_exit,
         use_nni=use_nni
     )
-    
-    # Save config file and repo state in checkpoint directory
-    _save_state(save_dir, config_path)
+
+    # Save config file in checkpoint directory
+    _save_config(save_dir, config_path)
 
     return out

--- a/xt_training/utils/training.py
+++ b/xt_training/utils/training.py
@@ -3,10 +3,11 @@ import shutil
 import nni
 from importlib.util import spec_from_file_location, module_from_spec
 
+import git
 import torch
 from torch.utils.tensorboard import SummaryWriter
 from xt_training import Runner, metrics
-from xt_training.utils import _import_config, Tee, functional
+from xt_training.utils import _import_config, Tee, functional, _save_state
 
 
 def train(args):
@@ -52,10 +53,7 @@ def train(args):
         use_nni=use_nni
     )
     
-    # Save config file
-    if isinstance(config_path, str):
-        shutil.copy(config_path, f'{save_dir}/config.py')
-    else:
-        shutil.copy(config['__file__'], f'{save_dir}/config.py')
+    # Save config file and repo state in checkpoint directory
+    _save_state(save_dir, config_path)
 
     return out

--- a/xt_training/utils/training.py
+++ b/xt_training/utils/training.py
@@ -3,7 +3,6 @@ import shutil
 import nni
 from importlib.util import spec_from_file_location, module_from_spec
 
-import git
 import torch
 from torch.utils.tensorboard import SummaryWriter
 from xt_training import Runner, metrics


### PR DESCRIPTION
This change allows us to keep track of the exact state of a git repo (if one exists) when xt-training was called.
* xt-training will now use the gitpython package to get the current commit hash, the list of untracked files, and the git patch corresponding to any unadded changes in the repo
* This information is saved to `f'{save_dir}/git.patch'`
* If the code calling xt-training doesn't live in a git repo, nothing happens
* This doesn't have any impact on the usage of the package
* To later replicate the environment used to create a particular checkpoint, we can just run the following:
    
    ```bash
    git checkout <saved commit hash>
    git apply <path to git.patch file in checkpoint directory>
    ```

* The above reproduction instructions are also included in the header of the git.patch files.

@simonrmonk this relates to some of the things we've spoken about recently. Before this change, we could never be sure what set of code generated a particular model artifact due to the possibility of local working changes. This goes most of the way to addressing that (not all the way - untracked files are only listed, their contents aren't saved).

@DavidBegert let me know what you think.

Change type:

- [ ] Bug fix
- [x] Feature
- [x] Documentation

Checklist:

- [x] My code follows the style guidelines of this [project](https://docs.google.com/document/d/1jckZJe0CrWyF-IjxoO2OfBKAyKLC3Yk9Xr7UmOLBETA/edit?usp=sharing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code and added docstrings to all exposed functions and classes
- [x] I have made corresponding changes to the documentation
- [x] Any relevant changes to third party licenses have been updated in the README
