### PR TITLE
Use black format for all py files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 import setuptools, os
 
-PACKAGE_NAME = 'xt-training'
-VERSION = '2.4.3'
-AUTHOR = 'Xtract AI'
-EMAIL = 'info@xtract.ai'
-DESCRIPTION = 'Utilities for training models in pytorch'
-GITHUB_URL = 'https://github.com/XtractTech/xt-training'
+PACKAGE_NAME = "xt-training"
+VERSION = "2.4.3"
+AUTHOR = "Xtract AI"
+EMAIL = "info@xtract.ai"
+DESCRIPTION = "Utilities for training models in pytorch"
+GITHUB_URL = "https://github.com/XtractTech/xt-training"
 
 parent_dir = os.path.dirname(os.path.realpath(__file__))
 
-with open(f'{parent_dir}/README.md', 'r') as f:
+with open(f"{parent_dir}/README.md", "r") as f:
     long_description = f.read()
 
 setuptools.setup(
@@ -19,27 +19,23 @@ setuptools.setup(
     author_email=EMAIL,
     description=DESCRIPTION,
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     url=GITHUB_URL,
-    packages=[
-        'xt_training',
-        'xt_training.utils',
-        'xt_training.utils.nni'
-    ],
-    package_data={'': ['*.json', '*.yml']},
-    provides=['xt_training'],
+    packages=["xt_training", "xt_training.utils", "xt_training.utils.nni"],
+    package_data={"": ["*.json", "*.yml"]},
+    provides=["xt_training"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'numpy',
-        'pandas',
-        'torch',
-        'scikit-learn>=0.22',
-        'plotly',
-        'pynvml',
-        'nni',
-        'gitpython',
+        "numpy",
+        "pandas",
+        "torch",
+        "scikit-learn>=0.22",
+        "plotly",
+        "pynvml",
+        "nni",
+        "gitpython",
     ],
 )

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -7,38 +7,38 @@ from xt_training.utils.logging import _save_state, _save_config
 
 
 def create_file(file_path):
-    open(file_path, 'a').close()
+    open(file_path, "a").close()
 
 
 @pytest.fixture
 def current_config_path(tmp_path):
 
-    config_path = Path(tmp_path).joinpath('current_config')
+    config_path = Path(tmp_path).joinpath("current_config")
     config_path.mkdir(parents=True)
 
-    config_file_path = config_path.joinpath('current_config.py')
+    config_file_path = config_path.joinpath("current_config.py")
     create_file(config_file_path)
 
     return config_file_path
 
 
-@pytest.fixture(name='repo')
+@pytest.fixture(name="repo")
 def dummy_git_repo(tmp_path):
 
     repo_path = tmp_path
     repo = git.Repo.init(repo_path)
 
-    file_name_temp = 'text_file.txt'
+    file_name_temp = "text_file.txt"
 
     file_path_temp = repo_path.joinpath(file_name_temp)
 
     create_file(file_path_temp)
     repo.index.add([file_name_temp])
-    repo.index.commit('dummy commit')
+    repo.index.commit("dummy commit")
 
-    file_path_temp.write_text('this text was not committed')
+    file_path_temp.write_text("this text was not committed")
 
-    create_file(repo_path.joinpath('an_untracked_file.py'))
+    create_file(repo_path.joinpath("an_untracked_file.py"))
 
     return repo
 
@@ -47,20 +47,24 @@ def test_save_state(repo, tmp_path, current_config_path):
 
     save_dir = tmp_path
     repo_path = repo.git.rev_parse("--show-toplevel")
-    
+
     expected_commit_hash = repo.head.object.hexsha
-    expected_untracked_file_name = 'an_untracked_file.py'
-    expected_diff_text = 'this text was not committed'
-    
+    expected_untracked_file_name = "an_untracked_file.py"
+    expected_diff_text = "this text was not committed"
+
     os.chdir(repo_path)
     _save_config(save_dir, str(current_config_path))
     _save_state(save_dir)
 
-    expected_output_file_path = Path(save_dir).joinpath('git.patch')
-    assert expected_output_file_path.exists(), 'git.patch file was not successfully created'
+    expected_output_file_path = Path(save_dir).joinpath("git.patch")
+    assert (
+        expected_output_file_path.exists()
+    ), "git.patch file was not successfully created"
 
     output_string = expected_output_file_path.read_text()
-    assert expected_commit_hash in output_string, 'Commit hash was not as expected'
-    assert expected_untracked_file_name in output_string, 'Untracked file list is incorrect'
-    assert expected_diff_text in output_string, 'Did not record diff of file'
+    assert expected_commit_hash in output_string, "Commit hash was not as expected"
+    assert (
+        expected_untracked_file_name in output_string
+    ), "Untracked file list is incorrect"
+    assert expected_diff_text in output_string, "Did not record diff of file"
 

--- a/xt_training/__main__.py
+++ b/xt_training/__main__.py
@@ -5,79 +5,74 @@ from .utils import train, template, test
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description='A tool for training/evaluating pytorch deep learning models'
+        description="A tool for training/evaluating pytorch deep learning models"
     )
-    subparsers = parser.add_subparsers(help='Subcommand help')
+    subparsers = parser.add_subparsers(help="Subcommand help")
 
     parser_train = subparsers.add_parser(
-        'train',
-        help='Train a model given a config script.',
-        description='Train a model given a config script.'
+        "train",
+        help="Train a model given a config script.",
+        description="Train a model given a config script.",
     )
     parser_train.add_argument(
-        'config_path',
+        "config_path", type=str, help="Path to fully specified config."
+    )
+    parser_train.add_argument(
+        "save_dir",
         type=str,
-        help='Path to fully specified config.'
+        help="Path to save model checkpoints, tensorboard runs, logs, and config files.",
     )
     parser_train.add_argument(
-        'save_dir',
-        type=str,
-        help='Path to save model checkpoints, tensorboard runs, logs, and config files.'
-    )
-    parser_train.add_argument(
-        '--overwrite', '-o',
-        action='store_true',
-        help='Switch to allow overwriting of existing path if necessary.'
+        "--overwrite",
+        "-o",
+        action="store_true",
+        help="Switch to allow overwriting of existing path if necessary.",
     )
     parser_train.set_defaults(func=train)
 
     parser_test = subparsers.add_parser(
-        'test',
-        help='Test a model given a config script.',
-        description='Test a model given a config script.'
+        "test",
+        help="Test a model given a config script.",
+        description="Test a model given a config script.",
     )
     parser_test.add_argument(
-        'config_path',
+        "config_path",
         type=str,
-        help='Path to fully specified config (if a file) or checkpoint directory (if a directory).'
+        help="Path to fully specified config (if a file) or checkpoint directory (if a directory).",
     )
     parser_test.add_argument(
-        'checkpoint_path',
+        "checkpoint_path",
         type=str,
-        help='Path to compatible model checkpoint.',
+        help="Path to compatible model checkpoint.",
         default=None,
-        nargs='?'
+        nargs="?",
     )
     parser_test.add_argument(
-        '--save_dir',
+        "--save_dir",
         type=str,
-        help='Path to save logs, config files, and (optionally) predictions.',
-        default=None
+        help="Path to save logs, config files, and (optionally) predictions.",
+        default=None,
     )
     parser_test.set_defaults(func=test)
 
     parser_template = subparsers.add_parser(
-        'template',
-        help='Generate a config script template.',
-        description='Generate a config script template.'
+        "template",
+        help="Generate a config script template.",
+        description="Generate a config script template.",
     )
     parser_template.add_argument(
-        'save_dir',
-        type=str,
-        help='Path to save config templates.'
+        "save_dir", type=str, help="Path to save config templates."
     )
     parser_template.add_argument(
-        '--nni',
-        action='store_true',
-        help='Generate nni template files.'
+        "--nni", action="store_true", help="Generate nni template files."
     )
     parser_template.set_defaults(func=template)
-    
+
     args = parser.parse_args()
 
     return args
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parse_args()
     args.func(args)

--- a/xt_training/utils/config_example.py
+++ b/xt_training/utils/config_example.py
@@ -51,17 +51,14 @@ from xt_training.utils import training, testing, functional
 
 # Dataset
 train_dataset = torch.utils.data.TensorDataset(
-    torch.rand(128, 3, 224, 224),
-    torch.randint(1000, (128,))
+    torch.rand(128, 3, 224, 224), torch.randint(1000, (128,))
 )
 val_dataset = torch.utils.data.TensorDataset(
-    torch.rand(16, 3, 224, 224),
-    torch.randint(1000, (16,))
+    torch.rand(16, 3, 224, 224), torch.randint(1000, (16,))
 )
 test_datasets = {
-    'test': torch.utils.data.TensorDataset(
-        torch.rand(16, 3, 224, 224),
-        torch.randint(1000, (16,))
+    "test": torch.utils.data.TensorDataset(
+        torch.rand(16, 3, 224, 224), torch.randint(1000, (16,))
     )
 }
 
@@ -72,20 +69,18 @@ train_loader = DataLoader(
     train_dataset,
     batch_size=batch_size,
     num_workers=num_workers,
-    sampler=RandomSampler(train_dataset)
+    sampler=RandomSampler(train_dataset),
 )
 val_loader = DataLoader(
     val_dataset,
     batch_size=batch_size,
     num_workers=num_workers,
-    sampler=SequentialSampler(val_dataset)
+    sampler=SequentialSampler(val_dataset),
 )
 test_loaders = {}
 for ds_name, ds in test_datasets.items():
     test_loaders[ds_name] = DataLoader(
-        ds,
-        batch_size=batch_size,
-        num_workers=num_workers,
+        ds, batch_size=batch_size, num_workers=num_workers,
     )
 
 # Model
@@ -94,9 +89,9 @@ model = models.resnet18(pretrained=True)
 # Loss and metrics
 loss_fn = nn.CrossEntropyLoss()
 eval_metrics = {
-    'acc': metrics.Accuracy(),
-    'util': metrics.GPUUtil(),
-    'mem': metrics.GPUMem()
+    "acc": metrics.Accuracy(),
+    "util": metrics.GPUUtil(),
+    "mem": metrics.GPUMem(),
 }
 
 # Optimizer

--- a/xt_training/utils/file_utils.py
+++ b/xt_training/utils/file_utils.py
@@ -5,12 +5,12 @@ from importlib.util import spec_from_file_location, module_from_spec
 
 def template(args):
     dir_path = os.path.dirname(os.path.realpath(__file__))
-    shutil.copy(os.path.join(dir_path, 'config_example.py'), args.save_dir)
+    shutil.copy(os.path.join(dir_path, "config_example.py"), args.save_dir)
     if args.nni:
-        nni_path = os.path.join(dir_path, 'nni')
-        shutil.copy(os.path.join(nni_path, 'config_example.py'), args.save_dir)
-        shutil.copy(os.path.join(nni_path, 'nni_config_example.yml'), args.save_dir)
-        shutil.copy(os.path.join(nni_path, 'search_space_example.json'), args.save_dir)
+        nni_path = os.path.join(dir_path, "nni")
+        shutil.copy(os.path.join(nni_path, "config_example.py"), args.save_dir)
+        shutil.copy(os.path.join(nni_path, "nni_config_example.yml"), args.save_dir)
+        shutil.copy(os.path.join(nni_path, "search_space_example.json"), args.save_dir)
 
 
 def _import_config(path):

--- a/xt_training/utils/logging.py
+++ b/xt_training/utils/logging.py
@@ -20,7 +20,7 @@ class Tee(object):
         self.file = open(logfile, "w")
         self.stdout = sys.stdout
         sys.stdout = self
-    
+
     def __enter__(self):
         return self
 
@@ -51,19 +51,19 @@ def _save_config(save_dir, config_path):
     # Save config file
     try:
         if isinstance(config_path, str):
-            shutil.copy(config_path, os.path.join(save_dir, 'config.py'))
+            shutil.copy(config_path, os.path.join(save_dir, "config.py"))
         else:
-            shutil.copy(config_path['__file__'], os.path.join(save_dir, 'config.py'))
+            shutil.copy(config_path["__file__"], os.path.join(save_dir, "config.py"))
     except shutil.SameFileError:
         pass
 
 
-PATCH_HEADER = '''
+PATCH_HEADER = """
 To replicate the git state used for this checkpoint, run the following:
 
     $ git checkout <commit hash shown below>
     $ git apply <path to this file>
-'''
+"""
 
 SESSION_HEADER = '''
 """The following code represents the most recent 200 lines of the python history leading up to calling
@@ -78,38 +78,38 @@ to describe the state at runtime. For cleaner state logging, try using an IPytho
 def _save_state(save_dir):
     # If we are in a git repo, save git state file
     try:
-        repo = git.Repo('.')
+        repo = git.Repo(".")
         commit = repo.head.object.hexsha
         untracked = repo.untracked_files
         diff = repo.git.diff()
 
-        with open(os.path.join(save_dir, 'git.patch'), 'w') as f:
+        with open(os.path.join(save_dir, "git.patch"), "w") as f:
             f.write(PATCH_HEADER)
-            f.write(f'\n\nCommit: {commit}')
-            f.write('\n\nUntracked files:\n')
-            f.write('\n'.join(untracked))
-            f.write('\n\n')
+            f.write(f"\n\nCommit: {commit}")
+            f.write("\n\nUntracked files:\n")
+            f.write("\n".join(untracked))
+            f.write("\n\n")
             f.write(diff)
     # Silently skip if no git repo is found
     except:
         pass
 
     # Save session history (for interactive sessions only)
-    if hasattr(sys, 'ps1'):
+    if hasattr(sys, "ps1"):
         # We are running in an interactive session
         try:
-            if hasattr(main, 'In'):
+            if hasattr(main, "In"):
                 # This is an IPython session (includes Jupyter)
-                with open(os.path.join(save_dir, 'session-ipython.py'), 'w') as f:
-                    f.write('\n'.join(main.In))
+                with open(os.path.join(save_dir, "session-ipython.py"), "w") as f:
+                    f.write("\n".join(main.In))
             else:
                 # Otherwise assume we are in the built-in python console
-                with open(os.path.join(save_dir, 'session.py'), 'w') as f:
+                with open(os.path.join(save_dir, "session.py"), "w") as f:
                     f.write(SESSION_HEADER)
                     history_len = readline.get_current_history_length()
                     # No way to limit to this session for python console
                     # Save only the most recent 200 lines
-                    for i in range(max(history_len-200, 0), history_len):
-                        f.write(readline.get_history_item(i + 1) + '\n')                    
+                    for i in range(max(history_len - 200, 0), history_len):
+                        f.write(readline.get_history_item(i + 1) + "\n")
         except:
             pass

--- a/xt_training/utils/nni/config_example.py
+++ b/xt_training/utils/nni/config_example.py
@@ -60,17 +60,14 @@ PARAMS = nni.get_next_parameter()
 
 # Dataset
 train_dataset = torch.utils.data.TensorDataset(
-    torch.rand(128, 3, 224, 224),
-    torch.randint(1000, (128,))
+    torch.rand(128, 3, 224, 224), torch.randint(1000, (128,))
 )
 val_dataset = torch.utils.data.TensorDataset(
-    torch.rand(16, 3, 224, 224),
-    torch.randint(1000, (16,))
+    torch.rand(16, 3, 224, 224), torch.randint(1000, (16,))
 )
 test_datasets = {
-    'test': torch.utils.data.TensorDataset(
-        torch.rand(16, 3, 224, 224),
-        torch.randint(1000, (16,))
+    "test": torch.utils.data.TensorDataset(
+        torch.rand(16, 3, 224, 224), torch.randint(1000, (16,))
     )
 }
 
@@ -81,20 +78,18 @@ train_loader = DataLoader(
     train_dataset,
     batch_size=batch_size,
     num_workers=num_workers,
-    sampler=RandomSampler(train_dataset)
+    sampler=RandomSampler(train_dataset),
 )
 val_loader = DataLoader(
     val_dataset,
     batch_size=batch_size,
     num_workers=num_workers,
-    sampler=SequentialSampler(val_dataset)
+    sampler=SequentialSampler(val_dataset),
 )
 test_loaders = {}
 for ds_name, ds in test_datasets.items():
     test_loaders[ds_name] = DataLoader(
-        ds,
-        batch_size=batch_size,
-        num_workers=num_workers,
+        ds, batch_size=batch_size, num_workers=num_workers,
     )
 
 # Model
@@ -103,14 +98,14 @@ model = models.resnet18(pretrained=True)
 # Loss and metrics
 loss_fn = nn.CrossEntropyLoss()
 eval_metrics = {
-    'acc': metrics.Accuracy(),
-    'util': metrics.GPUUtil(),
-    'mem': metrics.GPUMem()
+    "acc": metrics.Accuracy(),
+    "util": metrics.GPUUtil(),
+    "mem": metrics.GPUMem(),
 }
 
 # Optimizer
-#TODO: Example NNI code for accessing variable in search_space.json
-lr = PARAMS['lr'] if PARAMS else 1e-3
+# TODO: Example NNI code for accessing variable in search_space.json
+lr = PARAMS["lr"] if PARAMS else 1e-3
 optimizer = optim.Adam(model.parameters(), lr=lr)
 
 # Scheduler

--- a/xt_training/utils/testing.py
+++ b/xt_training/utils/testing.py
@@ -11,19 +11,18 @@ def test(args):
     config_path = args.config_path
     checkpoint_path = args.checkpoint_path
     save_dir = args.save_dir
-        
+
     if isinstance(config_path, str) and os.path.isdir(config_path):
         config_dir = config_path
-        config_path = os.path.join(config_dir, 'config.py')
+        config_path = os.path.join(config_dir, "config.py")
         assert checkpoint_path is None, (
             "checkpoint_path is not valid when config_path is a directory.\n"
             "\tSpecify either a config script and (optional) checkpoint individually, or\n"
             "\tspecify a directory containing both config.py and best.pt"
         )
-        checkpoint_path = os.path.join(config_dir, 'best.pt')
+        checkpoint_path = os.path.join(config_dir, "best.pt")
         if not save_dir:
             save_dir = config_dir
-    
 
     if isinstance(config_path, str):
         config = _import_config(config_path)
@@ -31,12 +30,12 @@ def test(args):
         config = config_path
 
     #  Load definitions
-    val_loader = getattr(config, 'val_loader', None)
-    test_loaders = getattr(config, 'test_loaders', None)
+    val_loader = getattr(config, "val_loader", None)
+    test_loaders = getattr(config, "test_loaders", None)
     model = config.model
-    loss_fn = getattr(config, 'loss_fn', lambda *_: torch.tensor(0.))
-    eval_metrics = getattr(config, 'eval_metrics', {'eps': metrics.EPS()})
-    on_exit = getattr(config, 'test_exit', functional.test_exit)
+    loss_fn = getattr(config, "loss_fn", lambda *_: torch.tensor(0.0))
+    eval_metrics = getattr(config, "eval_metrics", {"eps": metrics.EPS()})
+    on_exit = getattr(config, "test_exit", functional.test_exit)
 
     out = functional.test(
         save_dir,
@@ -46,7 +45,7 @@ def test(args):
         test_loaders,
         loss_fn,
         eval_metrics,
-        on_exit
+        on_exit,
     )
 
     # Save config file in checkpoint directory

--- a/xt_training/utils/training.py
+++ b/xt_training/utils/training.py
@@ -18,21 +18,21 @@ def train(args):
         config = _import_config(config_path)
     else:
         config = config_path
-    
+
     #  Load definitions
     train_loader = config.train_loader
-    val_loader = getattr(config, 'val_loader', None)
-    test_loaders = getattr(config, 'test_loaders', None)
+    val_loader = getattr(config, "val_loader", None)
+    test_loaders = getattr(config, "test_loaders", None)
     model = config.model
-    tokenizer = getattr(config, 'tokenizer', None)
+    tokenizer = getattr(config, "tokenizer", None)
     optimizer = config.optimizer
     epochs = config.epochs
-    scheduler = getattr(config, 'scheduler', None)
-    is_batch_scheduler = getattr(config, 'is_batch_scheduler', False)
+    scheduler = getattr(config, "scheduler", None)
+    is_batch_scheduler = getattr(config, "is_batch_scheduler", False)
     loss_fn = config.loss_fn
-    eval_metrics = getattr(config, 'eval_metrics', {'eps': metrics.EPS()})
-    on_exit = getattr(config, 'train_exit', functional.train_exit)
-    use_nni = getattr(config, 'use_nni', False)
+    eval_metrics = getattr(config, "eval_metrics", {"eps": metrics.EPS()})
+    on_exit = getattr(config, "train_exit", functional.train_exit)
+    use_nni = getattr(config, "use_nni", False)
 
     out = functional.train(
         save_dir,
@@ -49,7 +49,7 @@ def train(args):
         eval_metrics=eval_metrics,
         tokenizer=tokenizer,
         on_exit=on_exit,
-        use_nni=use_nni
+        use_nni=use_nni,
     )
 
     # Save config file in checkpoint directory


### PR DESCRIPTION
I propose that we always use Black formatting (and the Black autoformatter) for this package. It's easy enough to set up autoformatting in VSCode and will ensure that everything stays consistent. When we set up CI/CD for xt-training, we can add a format test to enforce this style. Let me know your thoughts.

Change type:

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation

Checklist:

- [x] My code follows the style guidelines of this [project](https://docs.google.com/document/d/1jckZJe0CrWyF-IjxoO2OfBKAyKLC3Yk9Xr7UmOLBETA/edit?usp=sharing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code and added docstrings to all exposed functions and classes
- [x] I have made corresponding changes to the documentation
- [x] Any relevant changes to third party licenses have been updated in the README
