### PR TITLE
Fixed path in setup.py that caused pip install to fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ GITHUB_URL = "https://github.com/XtractTech/xt-training"
 
 parent_dir = os.path.dirname(os.path.realpath(__file__))
 
-with open(f"{parent_dir}/README.md", "r") as f:
+with open(f"{parent_dir}/docs/README.md", "r") as f:
     long_description = f.read()
 
 setuptools.setup(


### PR DESCRIPTION
pip install was failing for me since `README.md` no longer exists. I fixed the path in setup.py and it's working now.

Change type:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation

Checklist:

- [x] My code follows the style guidelines of this [project](https://docs.google.com/document/d/1jckZJe0CrWyF-IjxoO2OfBKAyKLC3Yk9Xr7UmOLBETA/edit?usp=sharing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code and added docstrings to all exposed functions and classes
- [x] I have made corresponding changes to the documentation
- [x] Any relevant changes to third party licenses have been updated in the README
