### PR TITLE
Changed the on_exit call in functional.test to match functional.train

### DIFF
--- a/xt_training/utils/functional.py
+++ b/xt_training/utils/functional.py
@@ -231,7 +231,9 @@ def test(
                 else:
                     runner(loader, loader_name)
 
-        out = on_exit(test_loaders, model, runner, save_dir)
+        out = on_exit(
+            test_loaders=test_loaders, model=model, runner=runner, save_dir=save_dir
+        )
         torch.save(results, os.path.join(save_dir, "results.pt"))
 
         return out


### PR DESCRIPTION
This should allow custom on_exit functions to work on either functional.test or functional.train

Change type:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation

Checklist:

- [x] My code follows the style guidelines of this [project](https://docs.google.com/document/d/1jckZJe0CrWyF-IjxoO2OfBKAyKLC3Yk9Xr7UmOLBETA/edit?usp=sharing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code and added docstrings to all exposed functions and classes
- [x] I have made corresponding changes to the documentation
- [x] Any relevant changes to third party licenses have been updated in the README
